### PR TITLE
service api is using relative path

### DIFF
--- a/public/js/services/api.js
+++ b/public/js/services/api.js
@@ -2,7 +2,7 @@ app.factory('api',['$http', function($http){
   return function(met, uri, body, token, callback){
 	  	$http({
 		    method: met,
-		    url: 'http://localhost:3000/api/' + uri,
+		    url: '/api/' + uri,
 		    data: body,
 		    headers: {
 		    	'Content-Type': 'application/json',


### PR DESCRIPTION
Removing the localhost:3000 makes it possible to deploy the app to heroku as I've done it already:

https://todos-dafy.herokuapp.com

